### PR TITLE
company-dcd: add "etc/dmd.conf" and "etc/dmd/dmd.conf" to search path

### DIFF
--- a/company-dcd.el
+++ b/company-dcd.el
@@ -771,6 +771,12 @@ Else, read query."
 		      ;; working dir
 		      (concat (getenv "HOME") "/dmd.conf")
 		      (concat (company-dcd--parent-directory (executable-find "dmd")) "dmd.conf")
+		      (concat (company-dcd--parent-directory
+                	(company-dcd--parent-directory
+                	(executable-find "dmd"))) "etc/dmd.conf")
+		      (concat (company-dcd--parent-directory
+                	(company-dcd--parent-directory
+                	(executable-find "dmd"))) "etc/dmd/dmd.conf")
 		      "/etc/dmd.conf"))))
 
     ;; TODO: this extracting procedure is pretty rough, it just searches for

--- a/company-dcd.el
+++ b/company-dcd.el
@@ -783,7 +783,7 @@ Else, read query."
     ;; the first occurrence of the DFLAGS
     (save-window-excursion
       (with-temp-buffer
-        (find-file dmd-conf-filename)
+        (insert-file-contents dmd-conf-filename)
         (goto-char (point-min))
         (search-forward "\nDFLAGS")
         (skip-chars-forward " =")


### PR DESCRIPTION
Some package managers (such as macports) place the dmd.conf file in $PREFIX/etc/dmd. This patch add both $PREFIX/etc and $PREFIX/etc/dmd to the search paths.
