### PR TITLE
Allow using UNIX sockets or platform default as server address

### DIFF
--- a/company-dcd.el
+++ b/company-dcd.el
@@ -79,10 +79,22 @@ You can't put port number flag here.  Set `company-dcd--server-port' instead."
   :group 'company-dcd
   :type 'file)
 
-(defcustom company-dcd--server-port 9166
-  "Port number of dcd-server.  The default is 9166."
+(defcustom company-dcd-server-address nil
+  "Port number / UNIX socket path of dcd-server.
+
+Possible values:
+- nil - use DCD's default connection method
+- a number - use this TCP port (DCD's default is 9166)
+- a string - use this UNIX socket path
+
+The default is nil."
   :group 'company-dcd
-  :type 'integer)
+  :type '(choice
+	  (const :tag "Use platform default" nil)
+	  (integer :tag "Use this TCP port number")
+	  (file :tag "Use this UNIX socket path")))
+
+(define-obsolete-variable-alias 'company-dcd--server-port 'company-dcd-server-address)
 
 (defvar company-dcd--delay-after-kill-process 200
   "Duration to wait after killing the server process, in milliseconds.
@@ -109,6 +121,17 @@ If you need to restart the server, use `company-dcd-restart-server' instead."
   (interactive)
   (interrupt-process "dcd-server"))
 
+(defun company-dcd--server-address-flags ()
+  "Return the client/server command line flags indicating the server address."
+  (cond
+   ((null company-dcd-server-address) '())
+   ((numberp company-dcd-server-address)
+    (list "--tcp=true" "--port" (number-to-string company-dcd-server-address)))
+   ((stringp company-dcd-server-address)
+    (list "--tcp=false" "--socketFile" company-dcd-server-address))
+   (t
+    (error "Invalid value of company-dcd-server-address (%S)" company-dcd-server-address))))
+
 (defun company-dcd--start-server ()
   "Start dcd-server."
 
@@ -117,9 +140,8 @@ If you need to restart the server, use `company-dcd-restart-server' instead."
   
   (let (buf args proc)
     (setq buf (get-buffer-create company-dcd--server-buffer-name))
-    (setq args (nconc (list company-dcd-server-executable
-			    "-p"
-			    (format "%s" company-dcd--server-port))
+    (setq args (nconc (list company-dcd-server-executable)
+		      (company-dcd--server-address-flags)
 		      company-dcd--flags))
     (setq proc
 	  (with-current-buffer buf (apply 'start-process "dcd-server" (current-buffer) args)))
@@ -259,9 +281,7 @@ operate on complete symbols, such as --symbolLocation and --doc."
 
 Optionally, pass POS as the --cursorPos argument if non-nil."
   (nconc
-   (list
-    "--port"
-    (format "%s" company-dcd--server-port))
+   (company-dcd--server-address-flags)
    (when pos
      (list
       (concat "-I" default-directory)


### PR DESCRIPTION
- Allow specifying a string to use as a path to the UNIX socket name.
- Allow specifying `nil`, i.e. use DCD's default, which varies depending on the platform.
- Make `nil` (DCD platform default) the new default value.
- Update `defcustom` definition, to allow choosing from the above (and TCP port number) from the customization interface.
- DRY up DCD client/server command line generation code responsible for indicating the server address. (Old code used `"-p"` in one place and `"--port"` in another.)
- Update variable name (rename `company-dcd--server-port` to `company-dcd-server-address`) better convey its meaning.
  - Don't use private variable naming convention (`--`) for public, customizable variables.
  - Add alias for backwards compatibility.
